### PR TITLE
feat(db): import seed CSVs into MySQL

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -23,12 +23,12 @@ Schema: **sistema_controlo_ambiental2** (MySQL 8+).
 
 ## How to apply
 
-### With Docker (from project root, i.e. Sistema_de_Controlo_Ambiental)
+### With Docker (from project root)
 
 ```bash
 docker compose up -d db
-# When MySQL is ready:
-mysql -h 127.0.0.1 -P 3306 -u root -psca_root < database/schema.sql
+# When MySQL is ready (default host port 3307):
+docker exec -i sca-mysql mysql -u root -psca_root sistema_controlo_ambiental2 < database/schema.sql
 ```
 
 ### Local MySQL
@@ -38,3 +38,41 @@ mysql -u root -p < database/schema.sql
 ```
 
 Or run `schema.sql` in MySQL Workbench.
+
+## Seed data (CSV → MySQL)
+
+Generate CSVs (if needed):
+
+```bash
+cd database/scripts
+./generate_seed_csvs.sh
+```
+
+Import into the database (truncates and reloads all seed tables):
+
+```bash
+./database/import/import_csv.sh
+```
+
+Environment overrides (optional):
+
+| Variable | Default |
+| -------- | ------- |
+| `DB_HOST` | `127.0.0.1` |
+| `DB_PORT` | `3307` |
+| `DB_USER` | `root` |
+| `DB_PASSWORD` | `sca_root` |
+| `DB_NAME` | `sistema_controlo_ambiental2` |
+| `USE_DOCKER` | `1` (uses `docker exec` into `sca-mysql`) |
+| `MYSQL_CONTAINER` | `sca-mysql` |
+
+Import a single table:
+
+```bash
+./database/import/import_csv.sh tipos
+./database/import/import_csv.sh sensores leituras_sensor
+```
+
+**Order matters** for foreign keys. Use `all` (default) for a full reload.
+
+**Note:** Import assigns explicit ids `1..N` for casas, utilizadores, sensores, atuadores and leituras so CSV foreign keys stay valid. After import, disable `SYNC_MODELS=true` in backend dev or avoid `sequelize.sync({ alter: true })` on seeded tables.

--- a/database/import/import_csv.py
+++ b/database/import/import_csv.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+"""
+Load examination CSVs from database/scripts/generated/ into MySQL.
+
+Preserves row order so AUTO_INCREMENT ids match foreign keys in the CSVs
+(id_sensor 1..N, id_leitura 1..N, etc.).
+
+Usage:
+  python3 import_csv.py all
+  python3 import_csv.py tipos casas utilizadores
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+IMPORT_DIR = Path(__file__).resolve().parent
+GENERATED_DIR = IMPORT_DIR.parent / "scripts" / "generated"
+
+TABLES_IN_ORDER = [
+    "tipos",
+    "casas",
+    "utilizadores",
+    "casa_administradores",
+    "sensores",
+    "atuadores",
+    "leituras_sensor",
+    "acoes_sistema",
+    "parametros_automaticos",
+    "registos_consumo",
+]
+
+MYSQL_TABLES = {
+    "tipos": "Tipos",
+    "casas": "casas",
+    "utilizadores": "Utilizadores",
+    "casa_administradores": "Casa_Administradores",
+    "sensores": "sensores",
+    "atuadores": "atuadores",
+    "leituras_sensor": "leituras_sensor",
+    "acoes_sistema": "acoes_sistema",
+    "parametros_automaticos": "parametros_automaticos",
+    "registos_consumo": "registos_consumo",
+}
+
+TRUNCATE_ORDER = [MYSQL_TABLES[name] for name in reversed(TABLES_IN_ORDER)]
+
+
+def sql_literal(value: str | None) -> str:
+    if value is None or value == "":
+        return "NULL"
+    escaped = str(value).replace("\\", "\\\\").replace("'", "''")
+    return f"'{escaped}'"
+
+
+def load_config() -> dict[str, str]:
+    return {
+        "host": os.environ.get("DB_HOST", "127.0.0.1"),
+        "port": os.environ.get("DB_PORT", "3307"),
+        "user": os.environ.get("DB_USER", "root"),
+        "password": os.environ.get("DB_PASSWORD", "sca_root"),
+        "database": os.environ.get("DB_NAME", "sistema_controlo_ambiental2"),
+        "container": os.environ.get("MYSQL_CONTAINER", "sca-mysql"),
+        "use_docker": os.environ.get("USE_DOCKER", "1"),
+    }
+
+
+def run_sql(cfg: dict[str, str], sql: str) -> None:
+    if cfg["use_docker"] == "1":
+        cmd = [
+            "docker",
+            "exec",
+            "-i",
+            cfg["container"],
+            "mysql",
+            f"-u{cfg['user']}",
+            f"-p{cfg['password']}",
+            cfg["database"],
+        ]
+    else:
+        cmd = [
+            "mysql",
+            f"-h{cfg['host']}",
+            f"-P{cfg['port']}",
+            f"-u{cfg['user']}",
+            f"-p{cfg['password']}",
+            cfg["database"],
+        ]
+
+    subprocess.run(cmd, input=sql.encode("utf-8"), check=True)
+
+
+def read_csv(name: str) -> list[dict[str, str]]:
+    path = GENERATED_DIR / name
+    if not path.is_file():
+        raise FileNotFoundError(f"CSV not found: {path}")
+    with path.open(encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def truncate_all(cfg: dict[str, str]) -> None:
+    statements = ["SET FOREIGN_KEY_CHECKS = 0;"]
+    for table in TRUNCATE_ORDER:
+        statements.append(f"TRUNCATE TABLE `{table}`;")
+    statements.append("SET FOREIGN_KEY_CHECKS = 1;")
+    run_sql(cfg, "\n".join(statements))
+
+
+def import_tipos(cfg: dict[str, str]) -> None:
+    rows = read_csv("tipos_examination.csv")
+    if not rows:
+        return
+    values = []
+    for row in rows:
+        values.append(
+            "("
+            f"{sql_literal(row['classe'])}, "
+            f"{sql_literal(row['tipo'])}, "
+            f"{sql_literal(row['descricao'])}"
+            ")"
+        )
+    sql = (
+        "INSERT INTO `Tipos` (`classe`, `tipo`, `descrição`) VALUES\n"
+        + ",\n".join(values)
+        + ";"
+    )
+    run_sql(cfg, sql)
+    print(f"Tipos: {len(rows)} rows")
+
+
+def import_casas(cfg: dict[str, str]) -> None:
+    rows = read_csv("casas_examination.csv")
+    if not rows:
+        return
+    values = []
+    for index, row in enumerate(rows, start=1):
+        values.append(
+            "("
+            f"{index}, "
+            f"{sql_literal(row['nome'])}, "
+            f"{sql_literal(row['morada'])}, "
+            f"{sql_literal(row['codigo_postal'])}, "
+            f"{sql_literal(row['data_criacao'])}"
+            ")"
+        )
+    sql = (
+        "INSERT INTO `casas` "
+        "(`id_casa`, `nome`, `morada`, `codigo_postal`, `data_criacao`) VALUES\n"
+        + ",\n".join(values)
+        + ";\n"
+        f"ALTER TABLE `casas` AUTO_INCREMENT = {len(rows) + 1};"
+    )
+    run_sql(cfg, sql)
+    print(f"casas: {len(rows)} rows")
+
+
+def import_utilizadores(cfg: dict[str, str]) -> None:
+    rows = read_csv("utilizadores_examination.csv")
+    if not rows:
+        return
+    values = []
+    for index, row in enumerate(rows, start=1):
+        admin = row.get("admin", "0").strip() or "0"
+        values.append(
+            "("
+            f"{index}, "
+            f"{sql_literal(row['nome'])}, "
+            f"{sql_literal(row['email'])}, "
+            f"{sql_literal(row['palavra_passe_hash'])}, "
+            f"{sql_literal(row['data_criacao'])}, "
+            f"{admin}"
+            ")"
+        )
+    sql = (
+        "INSERT INTO `Utilizadores` "
+        "(`id_administrador`, `nome`, `email`, `palavra_passe_hash`, `data_criacao`, `admin`) "
+        "VALUES\n"
+        + ",\n".join(values)
+        + ";\n"
+        f"ALTER TABLE `Utilizadores` AUTO_INCREMENT = {len(rows) + 1};"
+    )
+    run_sql(cfg, sql)
+    print(f"Utilizadores: {len(rows)} rows")
+
+
+def import_casa_administradores(cfg: dict[str, str]) -> None:
+    rows = read_csv("casa_administradores_examination.csv")
+    if not rows:
+        return
+    values = []
+    for row in rows:
+        values.append(f"({row['id_casa'].strip()}, {row['id_utilizador'].strip()})")
+    sql = (
+        "INSERT INTO `Casa_Administradores` (`id_casa`, `id_utilizador`) VALUES\n"
+        + ",\n".join(values)
+        + ";"
+    )
+    run_sql(cfg, sql)
+    print(f"Casa_Administradores: {len(rows)} rows")
+
+
+def import_sensores(cfg: dict[str, str]) -> None:
+    rows = read_csv("sensores_examination.csv")
+    if not rows:
+        return
+    values = []
+    for index, row in enumerate(rows, start=1):
+        data_instalacao = row.get("data_instalacao", "").strip()
+        values.append(
+            "("
+            f"{index}, "
+            f"{sql_literal(row['nome'])}, "
+            f"{sql_literal(row['tipo_sensor'])}, "
+            f"{sql_literal(row['localizacao'])}, "
+            f"{sql_literal(row['estado'])}, "
+            f"{sql_literal(data_instalacao) if data_instalacao else 'NULL'}, "
+            f"{sql_literal(row['Tipos_classe'])}, "
+            f"{sql_literal(row['Tipos_tipo'])}"
+            ")"
+        )
+    sql = (
+        "INSERT INTO `sensores` "
+        "(`id_sensor`, `nome`, `tipo_sensor`, `localizacao`, `estado`, "
+        "`data_instalacao`, `Tipos_classe`, `Tipos_tipo`) VALUES\n"
+        + ",\n".join(values)
+        + ";\n"
+        f"ALTER TABLE `sensores` AUTO_INCREMENT = {len(rows) + 1};"
+    )
+    run_sql(cfg, sql)
+    print(f"sensores: {len(rows)} rows")
+
+
+def import_atuadores(cfg: dict[str, str]) -> None:
+    rows = read_csv("atuadores_examination.csv")
+    if not rows:
+        return
+    values = []
+    for index, row in enumerate(rows, start=1):
+        values.append(
+            "("
+            f"{index}, "
+            f"{sql_literal(row['nome'])}, "
+            f"{sql_literal(row['tipo_atuador'])}, "
+            f"{sql_literal(row['localizacao'])}, "
+            f"{sql_literal(row['estado'])}, "
+            f"{sql_literal(row['Tipos_classe'])}, "
+            f"{sql_literal(row['Tipos_tipo'])}"
+            ")"
+        )
+    sql = (
+        "INSERT INTO `atuadores` "
+        "(`id_atuador`, `nome`, `tipo_atuador`, `localizacao`, `estado`, "
+        "`Tipos_classe`, `Tipos_tipo`) VALUES\n"
+        + ",\n".join(values)
+        + ";\n"
+        f"ALTER TABLE `atuadores` AUTO_INCREMENT = {len(rows) + 1};"
+    )
+    run_sql(cfg, sql)
+    print(f"atuadores: {len(rows)} rows")
+
+
+def import_leituras_sensor(cfg: dict[str, str]) -> None:
+    rows = read_csv("leituras_sensor_examination.csv")
+    if not rows:
+        return
+    values = []
+    for index, row in enumerate(rows, start=1):
+        values.append(
+            "("
+            f"{index}, "
+            f"{row['id_sensor'].strip()}, "
+            f"{row['valor'].strip()}, "
+            f"{sql_literal(row['unidade'])}, "
+            f"{sql_literal(row['timestamp_leitura'])}"
+            ")"
+        )
+    sql = (
+        "INSERT INTO `leituras_sensor` "
+        "(`id_leitura`, `id_sensor`, `valor`, `unidade`, `timestamp_leitura`) VALUES\n"
+        + ",\n".join(values)
+        + ";\n"
+        f"ALTER TABLE `leituras_sensor` AUTO_INCREMENT = {len(rows) + 1};"
+    )
+    run_sql(cfg, sql)
+    print(f"leituras_sensor: {len(rows)} rows")
+
+
+def import_acoes_sistema(cfg: dict[str, str]) -> None:
+    rows = read_csv("acoes_sistema_examination.csv")
+    if not rows:
+        return
+    values = []
+    for row in rows:
+        motivo = row.get("motivo", "").strip()
+        values.append(
+            "("
+            f"{row['id_atuador'].strip()}, "
+            f"{sql_literal(row['tipo_acao'])}, "
+            f"{sql_literal(row['valor_aplicado'])}, "
+            f"{sql_literal(motivo) if motivo else 'NULL'}, "
+            f"{sql_literal(row['timestamp_acao'])}, "
+            f"{sql_literal(row['Tipos_classe'])}, "
+            f"{sql_literal(row['Tipos_tipo'])}"
+            ")"
+        )
+    sql = (
+        "INSERT INTO `acoes_sistema` "
+        "(`id_atuador`, `tipo_acao`, `valor_aplicado`, `motivo`, `timestamp_acao`, "
+        "`Tipos_classe`, `Tipos_tipo`) VALUES\n"
+        + ",\n".join(values)
+        + ";"
+    )
+    run_sql(cfg, sql)
+    print(f"acoes_sistema: {len(rows)} rows")
+
+
+def import_parametros_automaticos(cfg: dict[str, str]) -> None:
+    rows = read_csv("parametros_automaticos_examination.csv")
+    if not rows:
+        return
+    values = []
+    for row in rows:
+        descricao = row.get("descricao", "").strip()
+        values.append(
+            "("
+            f"{sql_literal(row['nome_parametro'])}, "
+            f"{sql_literal(row['valor_parametro'])}, "
+            f"{sql_literal(descricao) if descricao else 'NULL'}, "
+            f"{sql_literal(row['data_atualizacao'])}, "
+            f"{row['atuadores_id_atuador'].strip()}"
+            ")"
+        )
+    sql = (
+        "INSERT INTO `parametros_automaticos` "
+        "(`nome_parametro`, `valor_parametro`, `descricao`, `data_atualizacao`, "
+        "`atuadores_id_atuador`) VALUES\n"
+        + ",\n".join(values)
+        + ";"
+    )
+    run_sql(cfg, sql)
+    print(f"parametros_automaticos: {len(rows)} rows")
+
+
+def import_registos_consumo(cfg: dict[str, str]) -> None:
+    rows = read_csv("registos_consumo_examination.csv")
+    if not rows:
+        return
+    values = []
+    for row in rows:
+        values.append(
+            "("
+            f"{row['consumo'].strip()}, "
+            f"{sql_literal(row['unidade'])}, "
+            f"{sql_literal(row['periodo_inicio'])}, "
+            f"{sql_literal(row['periodo_fim'])}, "
+            f"{row['leituras_sensor_id_leitura'].strip()}"
+            ")"
+        )
+    sql = (
+        "INSERT INTO `registos_consumo` "
+        "(`consumo`, `unidade`, `periodo_inicio`, `periodo_fim`, "
+        "`leituras_sensor_id_leitura`) VALUES\n"
+        + ",\n".join(values)
+        + ";"
+    )
+    run_sql(cfg, sql)
+    print(f"registos_consumo: {len(rows)} rows")
+
+
+IMPORTERS = {
+    "tipos": import_tipos,
+    "casas": import_casas,
+    "utilizadores": import_utilizadores,
+    "casa_administradores": import_casa_administradores,
+    "sensores": import_sensores,
+    "atuadores": import_atuadores,
+    "leituras_sensor": import_leituras_sensor,
+    "acoes_sistema": import_acoes_sistema,
+    "parametros_automaticos": import_parametros_automaticos,
+    "registos_consumo": import_registos_consumo,
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Import generated CSVs into MySQL")
+    parser.add_argument(
+        "tables",
+        nargs="*",
+        choices=["all", *TABLES_IN_ORDER],
+        help="Tables to import (default: all)",
+    )
+    parser.add_argument(
+        "--no-truncate",
+        action="store_true",
+        help="Do not truncate tables before import (only with explicit table list)",
+    )
+    args = parser.parse_args()
+
+    selected = TABLES_IN_ORDER if not args.tables or "all" in args.tables else args.tables
+    for name in selected:
+        if name not in TABLES_IN_ORDER:
+            print(f"Unknown table: {name}", file=sys.stderr)
+            return 1
+
+    cfg = load_config()
+    if not GENERATED_DIR.is_dir():
+        print(f"Missing generated CSV folder: {GENERATED_DIR}", file=sys.stderr)
+        return 1
+
+    truncate = "all" in (args.tables or ["all"]) and not args.no_truncate
+    if truncate:
+        print("Truncating tables...")
+        truncate_all(cfg)
+
+    for name in selected:
+        print(f"Importing {name}...")
+        IMPORTERS[name](cfg)
+
+    print("Done.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/database/import/import_csv.sh
+++ b/database/import/import_csv.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Import examination CSVs into MySQL (Docker or local).
+#
+# Prerequisites:
+#   - Schema applied: database/schema.sql
+#   - CSVs in database/scripts/generated/ (run database/scripts/generate_seed_csvs.sh)
+#   - MySQL running (default: docker compose up -d db)
+#
+# Usage (from repo root or this folder):
+#   ./database/import/import_csv.sh
+#   ./database/import/import_csv.sh tipos casas
+#   USE_DOCKER=0 DB_PORT=3306 ./database/import/import_csv.sh all
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+export DB_HOST="${DB_HOST:-127.0.0.1}"
+export DB_PORT="${DB_PORT:-3307}"
+export DB_USER="${DB_USER:-root}"
+export DB_PASSWORD="${DB_PASSWORD:-sca_root}"
+export DB_NAME="${DB_NAME:-sistema_controlo_ambiental2}"
+export MYSQL_CONTAINER="${MYSQL_CONTAINER:-sca-mysql}"
+export USE_DOCKER="${USE_DOCKER:-1}"
+
+if [[ $# -eq 0 ]]; then
+  set -- all
+fi
+
+python3 import_csv.py "$@"


### PR DESCRIPTION
## Summary

Phase 0 — load examination data from `database/scripts/generated/` into MySQL so the API and frontend can use real rows instead of mocks.

- `database/import/import_csv.py` — imports all tables in FK order with stable ids (`1..N`)
- `database/import/import_csv.sh` — wrapper with Docker defaults (`sca-mysql`, port `3307`, `sca_root`)
- `database/README.md` — documented workflow

## Usage

```bash
docker compose up -d db
docker exec -i sca-mysql mysql -u root -psca_root sistema_controlo_ambiental2 < database/schema.sql
cd database/scripts && ./generate_seed_csvs.sh   # if CSVs missing
./database/import/import_csv.sh
```

## Imported row counts (tested)

| Table | Rows |
|-------|------|
| Tipos | 15 |
| casas | 10 |
| Utilizadores | 20 |
| Casa_Administradores | 25 |
| sensores | 20 |
| atuadores | 20 |
| leituras_sensor | 120 |
| acoes_sistema | 40 |
| parametros_automaticos | 35 |
| registos_consumo | 50 |

## Test plan

- [ ] `docker compose up -d db` and apply `database/schema.sql`
- [ ] Run `./database/import/import_csv.sh`
- [ ] `docker exec sca-mysql mysql -u root -psca_root sistema_controlo_ambiental2 -e "SELECT COUNT(*) FROM sensores"`
- [ ] Backend `npm run dev` can read seeded sensores after Phase 1 API changes

## Next steps

Follow-up PRs: replace backend mocks with Sequelize queries (Phase 1–2 of integration plan).